### PR TITLE
feat: add SDK pyproject.toml and development docs

### DIFF
--- a/.github/ci-python.md
+++ b/.github/ci-python.md
@@ -1,0 +1,54 @@
+CI Python & Test Setup
+
+This document describes how CI sets up the Python SDK and how to run the tests locally to mirror CI.
+
+CI Steps:
+
+- Setup Python using `actions/setup-python@v4` with `python-version: '3.11'`.
+- Create venv, upgrade pip, and install `pytest` and the local SDK in editable mode if possible:
+  - `python -m venv .venv`
+  - `source .venv/bin/activate`
+  - `pip install -U pip setuptools wheel`
+  - `pip install -e sdk/python || true` (some environments may skip editable mode)
+- Run pytest while skipping long-running integration/e2e tests and flaky tests in PRs:
+  - `pytest -q -m "not integration and not e2e and not flaky"`
+
+Local dev tips:
+
+- Prefer installing the SDK locally (`pip install -e sdk/python`) rather than setting `PYTHONPATH`.
+- You can set `PYTHONPATH` for one-off runs using `export PYTHONPATH=$(pwd)/sdk/python`.
+- Use pytest markers to run targeted tests: `pytest -m unit`, `pytest -m integration`, etc.
+
+CI Troubleshooting:
+
+- If imports fail in CI, ensure `pip install -e sdk/python` step ran successfully — check logs.
+- If CI still cannot import `mcp_sdk`, the fallback is to set `PYTHONPATH` in the job to `sdk/python`.
+  CI tips: make local `mcp_sdk` importable and install sdk in editable mode
+
+If your CI runs `pytest` and tests import the local SDK at `sdk/python`, either set `PYTHONPATH` or install the SDK in editable mode.
+
+Option A — set PYTHONPATH (no install required)
+
+```bash
+export PYTHONPATH=./sdk/python
+pytest -q -k "not integration"
+```
+
+Option B — install the SDK into the environment
+
+```bash
+python -m pip install -e sdk/python
+pytest -q -k "not integration"
+```
+
+GitHub Actions example step (Option B)
+
+```yaml
+- name: Install Python SDK and run tests
+  run: |
+    python -m pip install --upgrade pip
+    python -m pip install -e sdk/python
+    pytest -q -k "not integration"
+```
+
+Either approach ensures tests that import `mcp_sdk` succeed in CI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing & Development Guide
+
+Quick start for local development and running tests:
+
+1. Create and activate a Python virtual environment
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -U pip
+```
+
+2. Install the Python SDK locally (editable)
+
+```bash
+pip install -e sdk/python
+```
+
+Fallback: if you don't want to install, set PYTHONPATH for local runs
+
+```bash
+export PYTHONPATH="$(pwd)/sdk/python"
+```
+
+3. Run tests
+
+Unit tests (fast):
+
+```bash
+pytest -q -m "unit and not flaky"
+```
+
+Integration/E2E tests (slow):
+
+```bash
+pytest -q -m "integration or e2e"
+```
+
+4. Swift tests & builds
+
+Run SPM tests for the `Shared` package:
+
+```bash
+cd Shared
+swift test
+```
+
+Build MomentumFinance core target using SPM:
+
+```bash
+cd MomentumFinance
+swift build -v --target MomentumFinanceCore
+```
+
+Build full MomentumFinance app on macOS with xcodebuild
+
+```bash
+# If you have an Xcode workspace
+xcodebuild -workspace MomentumFinance/MomentumFinance.xcworkspace -scheme MomentumFinance -destination "platform=macOS" build
+```
+
+Notes:
+
+- The CI uses a conservative set of checks (unit tests, `swift test` for Shared, and `xcodebuild` for full app builds). Integration/E2E tests are run on longer-running workflows/nightly.
+- If a test appears flaky, tag it with the `@pytest.mark.flaky` marker and add a ticket to stabilize it or gate it to nightly runs.

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mcp-sdk"
+version = "1.0.0"
+description = "Python SDK for MCP (Model Context Protocol) server"
+readme = "README.md"
+requires-python = ">=3.8"
+keywords = ["mcp", "sdk", "api", "client", "automation"]
+authors = [ { name = "Tools Automation", email = "sdk@tools-automation.com" } ]
+license = { text = "MIT" }
+urls = { "Homepage" = "https://github.com/dboone323/tools-automation", "Bug Reports" = "https://github.com/dboone323/tools-automation/issues" }
+
+dependencies = [
+  "aiohttp>=3.8.0",
+  "typing-extensions>=4.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=7.0.0",
+  "pytest-asyncio>=0.21.0",
+  "black>=22.0.0",
+  "isort>=5.10.0",
+  "mypy>=1.0.0",
+  "flake8>=4.0.0",
+]
+
+[project.scripts]
+"mcp-cli" = "mcp_sdk:main"


### PR DESCRIPTION
## Extracted from PR #14

This PR extracts the valuable documentation and configuration changes from PR #14 without the large CI workflow changes.

### What's Included
- **sdk/python/pyproject.toml** - PEP 621 compliant project metadata
- **CONTRIBUTING.md** - Development setup guide with virtual env, SDK install, test commands
- **.github/ci-python.md** - CI/Python documentation

### Benefits
✅ Modern Python packaging (pyproject.toml)
✅ Clear contributor onboarding docs
✅ Editable SDK install instructions

### What's NOT Included
- Large CI workflow changes (300+ files)
- macOS xcodebuild job (needs separate evaluation)

Original PR #14 can be reviewed separately or closed after this merges.